### PR TITLE
Fix issue with TwigEnvironment loader's not used when provided

### DIFF
--- a/src/TwigTransformer.php
+++ b/src/TwigTransformer.php
@@ -11,11 +11,13 @@ class TwigTransformer extends Transformer
 {
     protected $twig;
     protected $loaders = array();
+    protected $twigProvided = false;
 
     public function __construct(array $options = array())
     {
         $this->loaders['string'] = new \Twig_Loader_String();
         if (isset($options['twig'])) {
+            $this->twigProvided = true;
             $this->twig = $options['twig'];
         } else {
             $this->twig = new Twig_Environment($this->loaders['string'], $options);
@@ -37,6 +39,10 @@ class TwigTransformer extends Transformer
 
     public function renderFile($file, array $locals = array())
     {
+        if ($this->twigProvided) {
+            // If Twig_Environment was provided, we must suppose its loaders are initialized too.
+            return trim($this->twig->render($file, $locals));
+        }
         // Construct a new loader from the base path.
         $path = dirname(realpath($file));
         if (!isset($this->loaders[$path])) {

--- a/tests/TwigTransformerTest.php
+++ b/tests/TwigTransformerTest.php
@@ -34,15 +34,18 @@ class TwigTransformerTest extends \PHPUnit_Framework_TestCase
         self::assertEquals('twig', $engine->getName());
     }
 
-    public function testConstructor()
+    public function testTwigProvided()
     {
-        $loader = new \Twig_Loader_Filesystem(__DIR__.DIRECTORY_SEPARATOR.'Fixtures');
+        $loader = new \Twig_Loader_Filesystem();
+        $loader->addPath(__DIR__.DIRECTORY_SEPARATOR.'Fixtures', 'test');
         $twig = new \Twig_Environment($loader);
         $engine = new TwigTransformer(array('twig' => $twig));
+
+        $template = '@test/TwigTransformer.twig';
         $locals = array(
             'name' => 'Linus',
         );
-        $actual = $engine->renderFile('tests/Fixtures/TwigTransformer.twig', $locals);
+        $actual = $engine->renderFile($template, $locals);
         self::assertEquals('Hello, Linus!', $actual);
     }
 }


### PR DESCRIPTION
Fix an issue when TwigEnvironment is passed to the TwigTransformer. The loader initialized with the TwigEnvironment is not used.

This PR fix it by storing in the class the fact that the transformer was created with an already created TwigEnvironment and use this information to directly use TwigEnvironment loader instead of creating a new one.

(Original PR: phptransformers/phptransformer#29)
